### PR TITLE
Use HTTPS clone string for GitLab

### DIFF
--- a/GitHelp/ghCloneOrigin.sh
+++ b/GitHelp/ghCloneOrigin.sh
@@ -12,22 +12,10 @@ fi
 
 CLONE_STRING=$1
 
-echo $CLONE_STRING | grep "gitlab" 1>/dev/null 2>&1
-IS_GITLAB=$?
-# 0=true   :-)
-
-if [ $IS_GITLAB -eq 0 ]; then
-    GIT_HOST=`echo $CLONE_STRING | cut -f 2 -d'@' | cut -f 1 -d':'`
-else
-    GIT_HOST=`echo $CLONE_STRING | cut -d/ -f3 `
-fi
+GIT_HOST=`echo $CLONE_STRING | cut -d/ -f3 `
 
 SSH_URL="git@$GIT_HOST"
-if [ $IS_GITLAB -eq 0 ]; then
-    GIT_URL="$SSH_URL:"
-else
-    GIT_URL="https://$GIT_HOST/"
-fi
+GIT_URL="https://$GIT_HOST/"
 
 printf "\nValidating SSH configuration...\n"
 printf "ssh -T $SSH_URL\n"
@@ -38,7 +26,7 @@ if [ $? -ne 0 ]; then
     printf "\n    Update $SSH_URL with your public SSH key, then run\n"
     printf "    the following command to complete and verify the configuration\n"
     printf "    before running this script again.\n"
-    printf "        ssh -T git@$SSH_URL\n"
+    printf "        ssh -T $SSH_URL\n"
     printf "\nOperation canceled.\n\n"
     exit 1
 fi
@@ -53,17 +41,9 @@ fi
 
 LOCAL_PARENT_DIRECTORY="$HOME/REPO"
 
-if [ $IS_GITLAB -eq 0 ]; then
-    GITHUB_USER=`echo $CLONE_STRING | awk -F ':' '{print $2}' | awk -F "/" '{print $1}'`
-else
-    GITHUB_USER=`echo $CLONE_STRING | awk -F '/' '{print $4}'`
-fi
+GITHUB_USER=`echo $CLONE_STRING | awk -F '/' '{print $4}'`
 
-if [ $IS_GITLAB -eq 0 ]; then
-    REPO_NAME=`echo $CLONE_STRING | awk -F ':' '{print $2}' | awk -F "/" '{print $2}'| cut -f 1 -d'.'`
-else
-    REPO_NAME=`echo $CLONE_STRING | awk -F '/' '{print $5}' | cut -f 1 -d'.'`
-fi
+REPO_NAME=`echo $CLONE_STRING | awk -F '/' '{print $5}' | cut -f 1 -d'.'`
 
 if [ -z $GITHUB_USER -o -z $REPO_NAME ]; then
   printf "\nBad clone string.\n"
@@ -88,15 +68,9 @@ if [ -d $REPO_ROOT ]; then
     exit 1
 fi
 
-if [ $IS_GITLAB -eq 0 ]; then
-    eval ORIGIN="${GIT_URL}${GITHUB_USER}/${REPO_NAME}.git"
-    eval PROFILE_URL="${GIT_URL}${GITHUB_USER}/${REPO_NAME}"
-    eval UPSTREAM="${GIT_URL}${UPSTREAM_OWNER}/${REPO_NAME}.git"
-else
-    eval ORIGIN="${GIT_URL}/${GITHUB_USER}/${REPO_NAME}"
-    eval PROFILE_URL="${GIT_URL}/${GITHUB_USER}/${REPO_NAME}"
-    eval UPSTREAM="${GIT_URL}/${UPSTREAM_OWNER}/${REPO_NAME}"
-fi
+eval ORIGIN="${GIT_URL}${GITHUB_USER}/${REPO_NAME}.git"
+eval PROFILE_URL="${GIT_URL}${GITHUB_USER}/${REPO_NAME}"
+eval UPSTREAM="${GIT_URL}${UPSTREAM_OWNER}/${REPO_NAME}.git"
 
 git config --global credential.helper cache
 

--- a/GitHelp/ghVERSION.sh
+++ b/GitHelp/ghVERSION.sh
@@ -1,3 +1,3 @@
-GITHELP_VERSION="4.0.4"
+GITHELP_VERSION="4.1.0"
 
 echo "GitHelp - Version $GITHELP_VERSION"


### PR DESCRIPTION
**Description**

The clone origin script currently expects users to use the SSH clone string for GitLab projects while expecting an HTTPS clone string for GitHub projects. The [GitHelp documentation](https://github.com/SiliconValleyOffice/GitHelp/wiki/First-Time-User#create-a-local-clone-of-your-origin) instructs users to use an HTTPS clone string for both. As I understand it, the ghCO script merely parses the GitLab string differently than the GitHub string with no functional difference between GitLab and GitHub in how the repository is cloned. To simplify the script and align with the documentation referenced above, this PR removes the expectation of an SSH clone string for GitLab instead only accepting HTTPS clone strings for both GitLab and GitHub with no difference in how the clone requests are handled.

**Validation Steps**

1. After checking out this branch and moving into the repository root, verify a GitLab project can be successfully cloned using the updated script:

```
./GitHelp/ghCloneOrigin.sh paste_https_clone_string_here upstream_owner name_of_development_branch Jira_Ticket_Prefix
```

2. Repeat the above step, this time verifying that a GitHub project can be successfully cloned.
