### PR TITLE
update ghNMRD to use defined development branch

### DIFF
--- a/GitHelp/ghNewMergeRequestForDevelopment.sh
+++ b/GitHelp/ghNewMergeRequestForDevelopment.sh
@@ -5,8 +5,8 @@
 if [ "$#" -gt 0 ]; then
   printf "\nUsage: ghNMRD\n"
   printf "    no arguments accepted\n"
-  printf "    upstream_branch = development\n\n"
+  printf "    upstream_branch = \'development\' = ${DEVELOPMENT_BRANCH}\n\n"
   exit 1
 fi
 
-$GITHELP_HOME/ghNewPullRequest.sh development
+$GITHELP_HOME/ghNewPullRequest.sh ${DEVELOPMENT_BRANCH}

--- a/GitHelp/ghVERSION.sh
+++ b/GitHelp/ghVERSION.sh
@@ -1,3 +1,3 @@
-GITHELP_VERSION="4.1.0"
+GITHELP_VERSION="4.1.1"
 
 echo "GitHelp - Version $GITHELP_VERSION"


### PR DESCRIPTION
- Updated ghNMRD from explicitly updating a branch named 'development' rather than the defined development branch
- this change makes ghNMRD consistent with [ghNPRD](https://github.com/SiliconValleyOffice/GitHelp/blob/development/GitHelp/ghNewPullRequestForDevelopment.sh)