### PR TITLE
Bugfix: Update MR/PR Links Generated for MRs/PRs on Forks

### DIFF
--- a/GitHelp/ghGitHubMergeRequestUrl.sh
+++ b/GitHelp/ghGitHubMergeRequestUrl.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 # Create a GitHub Merge Request URL
 
-if [ "$#" -ne 1 ]; then
-printf "\nUsage: ghGitLabMergeRequestUrl upstream_branch\n\n"
-exit 1
+if [ "$#" -lt 1 ]; then
+    printf "\nUsage: ghGitHubMergeRequestUrl target_branch target_project_owner\n\n"
+    printf "    target_project_owner = Fork project owner or defaults to upstream as project owner "
+    exit 1
 fi
 
-UPSTREAM_BRANCH=$1
+TARGET_BRANCH=$1
 CURRENT_BRANCH=`$GITHELP_HOME/ghCurrentBranchName.sh`
 CURRENT_USER=`git config --get remote.origin.url | awk -F/ '{print $5}' | sed s/\.git//`
-UPSTREAM_PROJECT=`git config --get remote.upstream.url | sed 's/git@//' | sed 's/com:/com\//' | sed 's/\.git//'`
 
-echo "$UPSTREAM_PROJECT/compare/${UPSTREAM_BRANCH}...$CURRENT_USER:$CURRENT_BRANCH?expand=1"
+if [ "$#" -eq 2 ]; then
+    TARGET_PROJECT_OWNER=$2
+else
+    TARGET_PROJECT_OWNER=upstream
+fi
+
+TARGET_PROJECT=`git config --get remote.$TARGET_PROJECT_OWNER.url | sed 's/git@//' | sed 's/com:/com\//' | sed 's/\.git//'`
+
+echo "$TARGET_PROJECT/compare/${TARGET_BRANCH}...$CURRENT_USER:$CURRENT_BRANCH?expand=1"
 

--- a/GitHelp/ghGitHubMergeRequestUrl.sh
+++ b/GitHelp/ghGitHubMergeRequestUrl.sh
@@ -2,7 +2,7 @@
 # Create a GitHub Merge Request URL
 
 if [ "$#" -lt 1 ]; then
-    printf "\nUsage: ghGitHubMergeRequestUrl target_branch target_project_owner\n\n"
+    printf "\nUsage: ghGitHubMergeRequestUrl target_branch [target_project_owner]\n\n"
     printf "    target_project_owner = Fork project owner or defaults to upstream as project owner "
     exit 1
 fi

--- a/GitHelp/ghGitLabMergeRequestUrl.sh
+++ b/GitHelp/ghGitLabMergeRequestUrl.sh
@@ -2,7 +2,7 @@
 # Create a GitLab Merge Request URL
 
 if [ "$#" -lt 1 ]; then
-    printf "\nUsage: ghGitLabMergeRequestUrl target_branch target_project_owner\n\n"
+    printf "\nUsage: ghGitLabMergeRequestUrl target_branch [target_project_owner]\n\n"
     printf "    target_project_owner = Fork project owner or defaults to upstream as project owner "
     exit 1
 fi

--- a/GitHelp/ghGitLabMergeRequestUrl.sh
+++ b/GitHelp/ghGitLabMergeRequestUrl.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 # Create a GitLab Merge Request URL
 
-if [ "$#" -ne 1 ]; then
-printf "\nUsage: ghGitLabMergeRequestUrl upstream_branch\n\n"
-exit 1
+if [ "$#" -lt 1 ]; then
+    printf "\nUsage: ghGitLabMergeRequestUrl target_branch target_project_owner\n\n"
+    printf "    target_project_owner = Fork project owner or defaults to upstream as project owner "
+    exit 1
 fi
 
-UPSTREAM_BRANCH=$1
+TARGET_BRANCH=$1
 CURRENT_BRANCH=`$GITHELP_HOME/ghCurrentBranchName.sh`
 ORIGIN_PROJECT_WITH_HTTP=`git config --get remote.origin.url | sed 's/git@//' | sed 's/com:/com\//' | sed 's/\.git//'`
 ORIGIN_PROJECT=`git config --get remote.origin.url | awk -F/ '{print $4 "/" $5}' | sed 's/\.git//'`
-UPSTREAM_PROJECT=`git config --get remote.upstream.url | awk -F/ '{print $4 "/" $5}' | sed 's/\.git//'`
 
-echo "${ORIGIN_PROJECT_WITH_HTTP}/merge_requests/new?merge_request%5Bsource_branch%5D=${CURRENT_BRANCH}&merge_request%5Bsource_project_id%5D=${ORIGIN_PROJECT}&merge_request%5Btarget_branch%5D=${UPSTREAM_BRANCH}&merge_request%5Btarget_project_id%5D=$UPSTREAM_PROJECT"
+if [ "$#" -eq 2 ]; then
+    TARGET_PROJECT_OWNER=$2
+else
+    TARGET_PROJECT_OWNER=upstream
+fi
+
+TARGET_PROJECT=`git config --get remote.$TARGET_PROJECT_OWNER.url | awk -F/ '{print $4 "/" $5}' | sed 's/\.git//'`
+
+echo "${ORIGIN_PROJECT_WITH_HTTP}/merge_requests/new?merge_request%5Bsource_branch%5D=${CURRENT_BRANCH}&merge_request%5Bsource_project_id%5D=${ORIGIN_PROJECT}&merge_request%5Btarget_branch%5D=${TARGET_BRANCH}&merge_request%5Btarget_project_id%5D=$TARGET_PROJECT"

--- a/GitHelp/ghNewPullRequestForFork.sh
+++ b/GitHelp/ghNewPullRequestForFork.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# New Pull Request for a Release branch
+# New Pull Request for a Fork branch
 # alias = ghNPRF
 
 if [ "$#" -ne 2 ]; then
@@ -86,16 +86,9 @@ fi
 printf "\n"
 
 if [ $IS_GITLAB -eq 0 ]; then
-    # UNTESTED !!!
-    UPSTREAM_BRANCH=$1
-    CURRENT_BRANCH=`$GITHELP_HOME/ghCurrentBranchName.sh`
-    ORIGIN_PROJECT_WITH_HTTP=`git config --get remote.origin.url | sed 's/git@//' | sed 's/com:/com\//'`
-    ORIGIN_PROJECT=`git config --get remote.origin.url | awk -F/ '{print $4 "/" $5}' | sed 's/\.git//'`
-    FORK_PROJECT=`git config --get remote.upstream.url | awk -F/ '{print $4 "/" $5}' | sed 's/\.git//' | sed s/$GITHUB_USER/$FORK_OWNER/`
-
-    echo "${ORIGIN_PROJECT_WITH_HTTP}/merge_requests/new?merge_request%5Bsource_branch%5D=${CURRENT_BRANCH}&merge_request%5Bsource_project_id%5D=${ORIGIN_PROJECT}&merge_request%5Btarget_branch%5D=${UPSTREAM_BRANCH}&merge_request%5Btarget_project_id%5D=$FORK_PROJECT"
+    UPSTREAM_URL=`$GITHELP_HOME/ghGitLabMergeRequestUrl.sh $FORK_BRANCH $FORK_OWNER`
 else
-    UPSTREAM_URL="$(git config --get remote.$FORK_OWNER.url | sed 's/git@//' | sed 's/com:/com\//' | sed 's/\.git//')/compare/${FORK_BRANCH}...${GITHUB_USER}:${CURRENT_BRANCH}?expand=1"
+    UPSTREAM_URL=`$GITHELP_HOME/ghGitHubMergeRequestUrl.sh $FORK_BRANCH $FORK_OWNER`
 fi
 
 if which google-chrome > /dev/null

--- a/GitHelp/ghVERSION.sh
+++ b/GitHelp/ghVERSION.sh
@@ -1,3 +1,3 @@
-GITHELP_VERSION="4.1.1"
+GITHELP_VERSION="4.1.2"
 
 echo "GitHelp - Version $GITHELP_VERSION"


### PR DESCRIPTION
**Description**

The links being generated for MRs on forks (e.g. the `ghNMRFMB` command) were incorrect. However, the links for MRs on the upstream project (e.g. the `ghNMRD` command) were correct. This PR updates the scripts being used to generate MR/PR links for requests on the upstream project so that they support requests on other forked projects, and then updates the request commands for forks to use the update scripts.

**Validation Steps**

* Setup the following test cases for GitLab and GitHub repositories:
  * Prepare a branch to submit an MR/PR to an upstream project.
  * Prepare a branch to submit an MR/PR to another developer's fork.

* Run `export GITHELP_HOME=~/REPO/GitHelp/GitHelp` so the scripts from this branch are used. Path assumes you've cloned GitHelp using GitHelp. Adjust if necessary to point to the location in which you've checked this PR out.

* For GitLab and GitHub test cases, submit an MR/PR to the upstream project using the `ghNMRFD` and `ghNPRFD` commands. Verify the appropriate page is opened in the browser.
* For the GitLab and GitHub test cases, submit an MR/PR to another developer's fork using the `ghNMRFMB` and `ghNPRFMB` commands. 
  * Note that when the GItLab page opens up, you'll likely see an error 'Target branch .... does not exist' and the target project will be set to the upstream project not another developer's fork. This is a known issue that will not be solved with this bug. An upcoming feature will resolve this issue. For now, if you select the correct project and then "Compare branches and continue", you'll be redirected to the appropriate MR draft page.

* Close and reopen your terminal or run `source ~/.bash_profile` to reset GITHELP_HOME to the normal setting.