### PR TITLE
Track Project Forks in Configuration File

### DIFF
--- a/GitHelp/bash_profile
+++ b/GitHelp/bash_profile
@@ -148,6 +148,7 @@ alias ghListUpstreamBranches="$GITHELP_HOME/ghListUpstreamBranches.sh"
 
 ###  F  ######
 alias ghLFB="$GITHELP_HOME/ghListForkBranches.sh"
+alias ghLFD="$GITHELP_HOME/ghListForkDevelopers.sh"
 alias ghListForkBranches="$GITHELP_HOME/ghListForkBranches.sh"
 alias ghFFJB="$GITHELP_HOME/ghFetchForkJiraBranch.sh"
 alias ghFetchForkJiraBranch="$GITHELP_HOME/ghFetchForkJiraBranch.sh"

--- a/GitHelp/ghGitLabMergeRequestUrl.sh
+++ b/GitHelp/ghGitLabMergeRequestUrl.sh
@@ -10,14 +10,41 @@ fi
 TARGET_BRANCH=$1
 CURRENT_BRANCH=`$GITHELP_HOME/ghCurrentBranchName.sh`
 ORIGIN_PROJECT_WITH_HTTP=`git config --get remote.origin.url | sed 's/git@//' | sed 's/com:/com\//' | sed 's/\.git//'`
-ORIGIN_PROJECT=`git config --get remote.origin.url | awk -F/ '{print $4 "/" $5}' | sed 's/\.git//'`
+
+# Default MR URL targets upstream main branch
+MR_URL="${ORIGIN_PROJECT_WITH_HTTP}/merge_requests/new?merge_request%5Bsource_branch%5D=${CURRENT_BRANCH}"
+
+# Change Target URL defaults to target upstream main branch, but prompts for project and branch selection
+MR_URL_CHANGE_TARGET="${ORIGIN_PROJECT_WITH_HTTP}/merge_requests/new?change_branches=true&merge_request%5Bsource_branch%5D=${CURRENT_BRANCH}"
 
 if [ "$#" -eq 2 ]; then
     TARGET_PROJECT_OWNER=$2
-else
-    TARGET_PROJECT_OWNER=upstream
+
+    DEV_LIST=$GIT_ROOT/.gitHelp/forkDevelopers.ini
+    $GITHELP_HOME/ghProjectConfigExists.sh $DEV_LIST
+    DEV_LIST_EXISTS=$?
+
+    # Verify fork developer configuration lists owner of target fork with ID
+    # Note: Warnings during validation are printed to standard error to prevent interferance
+    # with the MR URL being returned to the calling script.
+    if [[ $DEV_LIST_EXISTS -eq 0 && `grep $TARGET_PROJECT_OWNER "$DEV_LIST" | wc -w` -eq 2 ]]; then
+        
+        # Verify project ID is numerical
+        TARGET_PROJECT_ID=`grep $TARGET_PROJECT_OWNER "$DEV_LIST" | cut -d ' ' -f2`
+        if [[ $TARGET_PROJECT_ID =~ ^[0-9]+$ ]]; then
+            MR_URL="${ORIGIN_PROJECT_WITH_HTTP}/merge_requests/new?merge_request%5Bsource_branch%5D=${CURRENT_BRANCH}&merge_request%5Btarget_branch%5D=${TARGET_BRANCH}&merge_request%5Btarget_project_id%5D=$TARGET_PROJECT_ID"
+        else
+            printf "\nProject ID listed for $TARGET_PROJECT_OWNER's fork is invalid." >&2
+            printf "\nPlease correct project ID for $TARGET_PROJECT_OWNER in '${DEV_LIST}'.\n" >&2
+            printf "\nMeanwhile, you must manually select the appropriate target project and branch.\n" >&2
+            MR_URL=$MR_URL_CHANGE_TARGET
+        fi
+    else
+        printf "\nFork developer configuration missing." >&2
+        printf "\nTo configure, add username and project ID to '${DEV_LIST}'.\n" >&2
+        printf "\nMeanwhile, you must manually select the appropriate target project and branch.\n" >&2
+        MR_URL=$MR_URL_CHANGE_TARGET
+    fi  
 fi
 
-TARGET_PROJECT=`git config --get remote.$TARGET_PROJECT_OWNER.url | awk -F/ '{print $4 "/" $5}' | sed 's/\.git//'`
-
-echo "${ORIGIN_PROJECT_WITH_HTTP}/merge_requests/new?merge_request%5Bsource_branch%5D=${CURRENT_BRANCH}&merge_request%5Bsource_project_id%5D=${ORIGIN_PROJECT}&merge_request%5Btarget_branch%5D=${TARGET_BRANCH}&merge_request%5Btarget_project_id%5D=$TARGET_PROJECT"
+echo $MR_URL

--- a/GitHelp/ghHELP.sh
+++ b/GitHelp/ghHELP.sh
@@ -71,6 +71,7 @@ if [ "$1" == "-x" ]; then
     printf "$HELP_MESSAGE    ghLEB     -  List Epic Branches\n"
     printf "$HELP_MESSAGE    ======= F =========  Forks (not yours)  =============\n"
     printf "$HELP_MESSAGE    ghLFB     -  List Fork Branches\n"
+    printf "$HELP_MESSAGE    ghLFD     -  List Fork Developers\n"
     printf "$HELP_MESSAGE    ghFFJB    -  Fetch Fork JIRA Branch\n"
     printf "$HELP_MESSAGE    ghFFMB    -  Fetch Fork Misc Branch\n"
     printf "$HELP_MESSAGE    ghUBFJB   -  Update current Branch with Fork JIRA Branch\n"

--- a/GitHelp/ghListForkDevelopers.sh
+++ b/GitHelp/ghListForkDevelopers.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# list fork developers
+# alias = ghLFD
+
+if [ $# -ne 0 ]; then
+    printf "\nUsage: ghLFD\n"
+    printf "    List Fork Developers\n\n"
+    exit
+fi
+
+git rev-parse --show-toplevel &> /dev/null
+if [ $? -ne 0 ]; then
+    printf "\nFATAL ERROR:  Not a git repository directory\n\n"
+    exit 1;
+fi
+
+DEV_LIST=$GIT_ROOT/.gitHelp/forkDevelopers.ini
+
+# Verify dev list file exists and contains more than whitespace
+if [[ -f $DEV_LIST ]] && grep -q '[^[:space:]]' $DEV_LIST; then
+    printf "\nDevelopers with a Fork:\n\n"
+    cut -d ' ' -f1 $DEV_LIST
+else
+    printf "\nNo fork developers configured.\n"
+    printf "\nTo configure, add developers' usernames to $DEV_LIST.\n"
+fi

--- a/GitHelp/ghListForkDevelopers.sh
+++ b/GitHelp/ghListForkDevelopers.sh
@@ -16,11 +16,13 @@ fi
 
 DEV_LIST=$GIT_ROOT/.gitHelp/forkDevelopers.ini
 
-# Verify dev list file exists and contains more than whitespace
-if [[ -f $DEV_LIST ]] && grep -q '[^[:space:]]' $DEV_LIST; then
+$GITHELP_HOME/ghProjectConfigExists.sh $DEV_LIST
+DEV_LIST_EXISTS=$?
+
+if [ $DEV_LIST_EXISTS -eq 0 ]; then
     printf "\nDevelopers with a Fork:\n\n"
     cut -d ' ' -f1 $DEV_LIST
 else
-    printf "\nNo fork developers configured.\n"
+    printf "\nNo fork developers configured."
     printf "\nTo configure, add developers' usernames to $DEV_LIST.\n"
 fi

--- a/GitHelp/ghProjectConfigExists.sh
+++ b/GitHelp/ghProjectConfigExists.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Project config file exists and has non-whitespace
+
+CONFIG_FILE=$1
+[[ -f "$CONFIG_FILE" ]] && grep -q '[^[:space:]]' "$CONFIG_FILE"

--- a/GitHelp/ghVERSION.sh
+++ b/GitHelp/ghVERSION.sh
@@ -1,3 +1,3 @@
-GITHELP_VERSION="4.1.2"
+GITHELP_VERSION="4.2.0"
 
 echo "GitHelp - Version $GITHELP_VERSION"


### PR DESCRIPTION
**Description:**

It was discovered while working on [this PR](https://github.com/SiliconValleyOffice/GitHelp/pull/112) that in order to complete certain tasks for GitLab projects, like formulate a link for creating an MR into another developers fork, the specific forked project id has to be known. This id can only be determined via an authenticated request to the GitLab API. To avoid the messiness of interacting with the GitLab API, a configuration file which lists namespaces and projects ids for each fork of a project can be used so GitHelp has the necessary information to improve existing commands and add new ones for GitLab projects. This PR adds dependence on a `.gitHelp/forkDevelopers.ini` file in the root of a project to enable a new command `ghLFD` which lists fork developers and to enable the `ghNMRFMB`/`ghNMRFJB` commands to generated direct links for MRs into other developer’s forks.

Note: The minor version has been incremented since this was a feature addition.

**Validation Steps:**
* To utilize this version of GitHelp with the new commands for validation steps, complete the following setup:
    * Copy the contents of `bash_profile` into your `~/.bash_profile` file, replacing the existing GitHelp content that is there. This adds the new command: `ghLFD`.
    * At the top of the GitHelp section in `~/.bash_profile`, change the value of `GITHELP_HOME` to `~/REPO/GitHelp/GitHelp` or wherever you have the cloned working version of GitHelp located.
    * Run `source ~/.bash_profile`.
    * You can run `alias` to validate that the new `ghLFD` command is present and that all the `gh` commands now point to the working directory for GitHelp rather than the installed directory.
* Validate the `ghLFD` command works (note the following validation can be completed on a GitHub or GitLab project):
    * In a repository without a `.gitHelp/forkDevelopers.ini` file, run `ghLFD`. Confirm that an error message is returned.
    * In that same repository, create a GitHelp directory `mkDir .gitHelp`, and create an empty file: `touch .gitHelp/forkDevelopers.ini`. Run `ghLFD`. Confirm that the same error message is returned.
    * Add a list of usernames, following the format for a GitHub project [here](https://github.com/SiliconValleyOffice/GitHelp/wiki/Project-Configurations#format): one username per line. Run `ghLFD`. Confirm that the usernames are printed as they are stored in the config file.
    * Add project IDs for each username, following the format for a GitLab project [here](https://github.com/SiliconValleyOffice/GitHelp/wiki/Project-Configurations#format): username projectID. Run `ghLFD`. Confirm that the usernames are printed as they are stored in the config file. Project IDs should not be printed.
*  Validate the `ghNMRFMB` command works for a GitLab project (since `ghNMRFJB` uses the same underlying files, the following steps also validate that command works):
    * In a cloned GitLab project, create a branch off of one of another developer’s Fork branches using the `ghFFMB` command.
    * Make a change, then add push and commit using `ghACP`.
    * If the current project has a `.gitHelp/forkDevelopers.ini` file already, temporarily rename that file to `forkDevelopers2.ini`. Note you’ll have to run `ghACP` each time before you run the merge request command after making a change.
    * Run `ghNMRFMB` and validate that after confirming the desire to create an MR, the MR page opens in chrome which allows you to select a target project and branch. The console has a warning message since the config file doesn’t exist.
    * Then create an empty `forkDevelopers.ini` file. Run `ghNMRFMB` and validate that after confirming the desire to create an MR, the MR page opens in chrome which allows you to select a target project and branch. The console has a warning message since the config file is blank.
    * Next, add usernames only to `forkDevelopers.ini`. Run `ghNMRFMB` and validate that after confirming the desire to create an MR, the MR page opens in chrome which allows you to select a target project and branch. The console has a warning message since the project ID is missing.
    * Add project IDs, but make them nonnumerical (including at least one letter in each ID). Run `ghNMRFMB` and validate that after confirming the desire to create an MR, the MR page opens in chrome which allows you to select a target project and branch. The console has a warning message since the project ID is invalid.
    * If the project has a `.gitHelp/forkDevelopers.ini` file that you temporarily renamed earlier, delete the new `forkDevelopers.ini` file you were playing with and revert the name change on the original file (otherwise, just correct the project IDs in the new `forkDevelopers.ini` file so that they are accurate).
    * Run `ghNMRFMB` and validate that you are directed to an MR draft with the correct target branch and project to merge into another Developer’s Fork.

**Review Wiki Updates**:

* Updated [Collaborating in Another Developer’s Fork](https://github.com/SiliconValleyOffice/GitHelp/wiki/Collaborating-in-Another-Developer's-Fork/_compare/fc68367781ee2b6ac68d1d514eade5968216880d...41f2017d235ccfcc4aec4c504dee895843d91eeb)
* Added [Project Configurations](https://github.com/SiliconValleyOffice/GitHelp/wiki/Project-Configurations)
* Updated [First Time User](https://github.com/SiliconValleyOffice/GitHelp/wiki/First-Time-User/_compare/b1abfaf1bb66e07a3ff3720bcc3bf3c64f1fdd87...7a572763d95b14aa515d2d6fc4e4215eab5ab960)
